### PR TITLE
Prompt for CRA username and password.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -85,6 +85,14 @@ else
     COMPOSE_BUILD_ARGS="--build"
 fi
 
+# Read CRA credentials
+read -p "CRA username: " TS_CRA_USERNAME
+read -s -p "CRA password (characters will not be displayed as you type): " TS_CRA_PASSWORD
+echo
+
+export TS_CRA_USERNAME
+export TS_CRA_PASSWORD
+
 # Bring up service with docker-compose.
 docker-compose $COMPOSE_FILE_ARGS up -d $COMPOSE_BUILD_ARGS
 


### PR DESCRIPTION
This has `run.sh` ask for a username and password for the CIPRES REST API (CRA), and exports both as environment variables for the CloudForest container.

The password is prompted for with the `-s` flag s.t. the characters are not displayed as the user types.