### PR TITLE
Updates to use new Docker Hub image repository.

### DIFF
--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -1,3 +1,3 @@
 services:
   cloudforest:
-    image: cloudforestphylogenomics/cloudforest_galaxy:$CLOUDFOREST_TAG
+    image: cloudforestphylo/cloudforestgalaxy:$CLOUDFOREST_TAG

--- a/guides/cloudforest_dev_guide.html
+++ b/guides/cloudforest_dev_guide.html
@@ -162,7 +162,7 @@
 <li><p>CloudForest Docker</p>
 <p>Docker and ancillary files for bundling the application into a Galaxy workflow image</p></li>
 </ol>
-<p>The code units are brought together to build and publish a Docker container on <a href="https://hub.docker.com/repository/docker/cloudforestphylogenomics/cloudforest_galaxy">Docker Hub</a>.</p>
+<p>The code units are brought together to build and publish a Docker container on <a href="https://hub.docker.com/repository/docker/cloudforestphylo/cloudforestgalaxy">Docker Hub</a>.</p>
 <h2 id="general-development-flow">General Development Flow</h2>
 <p><img src="DevFlow3.png" /></p>
 <h2 id="github-repositories">Github Repositories</h2>
@@ -194,7 +194,7 @@
 <p>CloudForest can be configured to use <a href="https://github.com/bgruening/docker-galaxy-stable#Running-on-an-external-cluster-(DRM)">external compute clusters</a>. This functionality is not enabled for the current release.</p>
 <h3 id="docker-and-data-permanence">Docker and Data Permanence</h3>
 <p>Docker containers run within a non-local environment, once the Docker engine stops the container all state is lost. Running CloudForest with the following command</p>
-<pre><code>docker run -d -p 8080:80 --name cf_galaxy -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=4&quot; cloudforestphylogenomics/cloudforest_galaxy:latest</code></pre>
+<pre><code>docker run -d -p 8080:80 --name cf_galaxy -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=4&quot; cloudforestphylo/cloudforestgalaxy:latest</code></pre>
 <p>will not let the user save data files. If they have downloaded the files into their local filesystem the data is, of course, saved. Docker has two methods for persisting data from the container into the local file space: <strong>volumes</strong> and <strong>bind mounts</strong>.</p>
 <h4 id="volumes">Volumes</h4>
 <p>Docker <a href="https://docs.docker.com/storage/volumes/">volumes</a> are similar to containers and are fully managed via docker commands. Data is persisted within a volume and any volume can be shared between containers. For CloudForest, volumes are now preferred to bind mounts.</p>
@@ -203,7 +203,7 @@
 </blockquote>
 <p>Data persistence with volumes can be achieved by 1) creating the volume, and 2) running the Galaxy container with volume mapped in:</p>
 <pre><code>docker volume create cloudforest-volume
-docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylogenomics/cloudforest_galaxy:latest</code></pre>
+docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylo/cloudforestgalaxy:latest</code></pre>
 <h4 id="bind-mounts">Bind Mounts</h4>
 <p>Docker <a href="https://docs.docker.com/storage/bind-mounts/">bind mounts</a> are the original method for persisting data out of a running container. This method is not preferred, but instructions are listed below for interested users.</p>
 <p>Bind mounts open a filesystem channel from the container out to the host file system. When mounted, the container will write files directly to host space. This is the general form of the command:</p>
@@ -211,7 +211,7 @@ docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,ta
 <p>The -v argument maps the container directory <em>/app</em> to the host directory <em>/local/system/path/target</em>. Any file the containerized application writes to <em>/app</em> is written into the host file system. When the container is stopped, the data continues to exist on the host. The mapping works in both directions. A user can add files into the host directory and the files are visible from within the running container.</p>
 <p><strong>Note</strong>: On MacOS the host directory used for the bind mount may need allowed in Docker Desktop. This can be done by navigating to <code>Preferences -&gt; Resources -&gt; File Sharing</code> and adding the directory the list found there.</p>
 <p>Starting CloudForest using bind mounts:</p>
-<pre><code>docker run -d -p 8080:80 --name cloudforest -v /home/jdoe/galaxy_storage/:/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylogenomics/cloudforest_galaxy:latest</code></pre>
+<pre><code>docker run -d -p 8080:80 --name cloudforest -v /home/jdoe/galaxy_storage/:/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylo/cloudforestgalaxy:latest</code></pre>
 <p>The LHS of the colon can be any legal, local OS path. The RHS of the colon <strong>must</strong> be <em>/export/</em>. The base Galaxy image has been coded to use <em>/export/</em> as its app root directory.</p>
 <p>As long as the LHS path is used for each application start, CloudForest will use the DB and files saved from the last run. If another LHS path is used, CloudForest will start with a blank DB and no data files.</p>
 <p>You can see why using Docker volumes is a clean method of data transfer. Bind mounts tie saved data to the local file system structure, while Docker volumes abstract away the local environment. This abstraction does come at the cost of using more Docker commands. Nullum gratuitum prandium.</p>

--- a/guides/cloudforest_guide.html
+++ b/guides/cloudforest_guide.html
@@ -159,18 +159,18 @@
 <h3 id="docker-installation">Docker Installation</h3>
 <p>To run CloudForest, you will have to install Docker. Please follow these <a href="https://www.docker.com/products/docker-desktop"><strong>instructions</strong></a> to install Docker for your operating system.</p>
 <h3 id="docker-pull-and-run-commands">Docker Pull and Run Commands</h3>
-<p>The CloudForest Docker image is stored on <a href="https://hub.docker.com/repository/docker/cloudforestphylogenomics/cloudforest_galaxy"><strong>Docker hub</strong></a>.</p>
+<p>The CloudForest Docker image is stored on <a href="https://hub.docker.com/repository/docker/cloudforestphylo/cloudforestgalaxy"><strong>Docker hub</strong></a>.</p>
 <blockquote>
 <p><strong>NB: Docker commands are run from the terminal command line.</strong></p>
 </blockquote>
 <h4 id="pulling-the-image">Pulling the Image</h4>
 <p>You can download the image to your computer with the following <a href="https://docs.docker.com/engine/reference/commandline/pull/"><strong>command</strong></a>:</p>
-<pre><code>docker pull cloudforestphylogenomics/cloudforest_galaxy:latest</code></pre>
+<pre><code>docker pull cloudforestphylo/cloudforestgalaxy:latest</code></pre>
 <p>This command contacts Docker hub and pulls down the latest image of CloudForest.</p>
 <p>You can verify the download with the command:</p>
 <pre><code>docker images</code></pre>
 <p>You will see something like this:</p>
-<pre><code>cloudforestphylogenomics/cloudforest_galaxy  latest  160a642eee15  4 days ago  2.12GB</code></pre>
+<pre><code>cloudforestphylo/cloudforestgalaxy  latest  160a642eee15  4 days ago  2.12GB</code></pre>
 <p>The number <em>160a642eee15</em> is an arbitraty ID assigned to the container by Docker. You do not have to use the ID number.</p>
 <h4 id="running-a-docker-image">Running a Docker Image</h4>
 <p>In general you run any image with the following <a href="https://docs.docker.com/engine/reference/commandline/run/"><strong>command</strong></a>:</p>
@@ -211,11 +211,11 @@ $ docker run -it ubuntu bash</code></pre>
 <p>The <em><strong>-e</strong></em> flag sets environment variables inside the container. In this case we are telling CloudForest to run all tools within the container. It is possible to run tools on <a href="https://github.com/bgruening/docker-galaxy-stable#Running-on-an-external-cluster-(DRM)">HPC compute nodes or external clusters</a>. Using external clusters is outside the scope of this document.</p></li>
 <li><p>-e “GALAXY_SLOTS=2”</p>
 <p>This varible starts the application with 2 threads. If you have a local machine with multiple cores, you can increase this number.</p></li>
-<li><p>cloudforestphylogenomics/cloudforest_galaxy:latest</p>
+<li><p>cloudforestphylo/cloudforestgalaxy:latest</p>
 <p>This is the docker image. If you have pulled the image, docker will run with the locally cached image. If you have <em>not</em> pulled the image, docker will first pull the image from the docker hub and then run the container.</p></li>
 </ul>
 <p>Docker does allow for data persistence over time. This is done by mapping a docker volume into the container.</p>
-<pre><code>docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylogenomics/cloudforest_galaxy:latest</code></pre>
+<pre><code>docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e &quot;GALAXY_DESTINATIONS_DEFAULT=local_no_container&quot; -e &quot;GALAXY_SLOTS=2&quot; cloudforestphylo/cloudforestgalaxy:latest</code></pre>
 <p>The <em><strong>–mount</strong></em> option is used for volume mapping.</p>
 <pre><code>--mount source=cloudforest-volume,target=/export/</code></pre>
 <p>Volumes can be created like so:</p>

--- a/guides/docker_dev.md
+++ b/guides/docker_dev.md
@@ -14,7 +14,7 @@ CloudForest is comprised of three separate code units:
 
     Docker and ancillary files for bundling the application into a Galaxy workflow image
 
-The code units are brought together to build and publish a Docker container on [Docker Hub](https://hub.docker.com/repository/docker/cloudforestphylogenomics/cloudforest_galaxy).
+The code units are brought together to build and publish a Docker container on [Docker Hub](https://hub.docker.com/repository/docker/cloudforestphylo/cloudforestgalaxy).
 
 ## General Development Flow
 
@@ -73,7 +73,7 @@ CloudForest can be configured to use [external compute clusters](https://github.
 
 Docker containers run within a non-local environment, once the Docker engine stops the container all state is lost. Running CloudForest with the following command
 
-    docker run -d -p 8080:80 --name cf_galaxy -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=4" cloudforestphylogenomics/cloudforest_galaxy:latest
+    docker run -d -p 8080:80 --name cf_galaxy -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=4" cloudforestphylo/cloudforestgalaxy:latest
 
 will not let the user save data files. If they have downloaded the files into their local filesystem the data is, of course, saved. Docker has two methods for persisting data from the container into the local file space: **volumes** and **bind mounts**.
 
@@ -86,7 +86,7 @@ Docker [volumes](https://docs.docker.com/storage/volumes/) are similar to contai
 Data persistence with volumes can be achieved by 1) creating the volume, and 2) running the Galaxy container with volume mapped in:
 
 	docker volume create cloudforest-volume
-	docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylogenomics/cloudforest_galaxy:latest
+	docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylo/cloudforestgalaxy:latest
 
 #### Bind Mounts
 
@@ -103,7 +103,7 @@ The -v argument maps the container directory */app* to the host directory */loca
 
 Starting CloudForest using bind mounts:
 
-    docker run -d -p 8080:80 --name cloudforest -v /home/jdoe/galaxy_storage/:/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylogenomics/cloudforest_galaxy:latest
+    docker run -d -p 8080:80 --name cloudforest -v /home/jdoe/galaxy_storage/:/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylo/cloudforestgalaxy:latest
 
 The LHS of the colon can be any legal, local OS path. The RHS of the colon **must** be */export/*. The base Galaxy image has been coded to use */export/* as its app root directory.
 

--- a/guides/usage_notes.md
+++ b/guides/usage_notes.md
@@ -12,7 +12,7 @@ To run CloudForest, you will have to install Docker. Please follow these [**inst
 
 ### Docker Pull and Run Commands
 
-The CloudForest Docker image is stored on [**Docker hub**](https://hub.docker.com/repository/docker/cloudforestphylogenomics/cloudforest_galaxy).
+The CloudForest Docker image is stored on [**Docker hub**](https://hub.docker.com/repository/docker/cloudforestphylo/cloudforestgalaxy).
 
 > **NB: Docker commands are run from the terminal command line.**
 
@@ -20,7 +20,7 @@ The CloudForest Docker image is stored on [**Docker hub**](https://hub.docker.co
 
 You can download the image to your computer with the following [**command**](https://docs.docker.com/engine/reference/commandline/pull/):
 
-    docker pull cloudforestphylogenomics/cloudforest_galaxy:latest
+    docker pull cloudforestphylo/cloudforestgalaxy:latest
 
 This command contacts Docker hub and pulls down the latest image of CloudForest.
 
@@ -30,7 +30,7 @@ You can verify the download with the command:
 
 You will see something like this:
 
-    cloudforestphylogenomics/cloudforest_galaxy  latest  160a642eee15  4 days ago  2.12GB
+    cloudforestphylo/cloudforestgalaxy  latest  160a642eee15  4 days ago  2.12GB
 
 The number _160a642eee15_ is an arbitraty ID assigned to the container by Docker. You do not have to use the ID number.  
 
@@ -99,13 +99,13 @@ The `run.sh` simply manages these user options (`./run.sh --usage` will display 
 
     This varible starts the application with 2 threads. If you have a local machine with multiple cores, you can increase this number.
 
-* cloudforestphylogenomics/cloudforest_galaxy:latest
+* cloudforestphylo/cloudforestgalaxy:latest
 
     This is the docker image. If you have pulled the image, docker will run with the locally cached image. If you have *not* pulled the image, docker will first pull the image from the docker hub and then run the container.
 
 Docker does allow for data persistence over time. This is done by mapping a docker volume into the container.
 
-    docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylogenomics/cloudforest_galaxy:latest
+    docker run -d -p 8080:80 --name cloudforest --mount source=cloudforest-volume,target=/export/ -e "GALAXY_DESTINATIONS_DEFAULT=local_no_container" -e "GALAXY_SLOTS=2" cloudforestphylo/cloudforestgalaxy:latest
 
 The *__--mount__* option is used for volume mapping.
 

--- a/run.sh
+++ b/run.sh
@@ -37,6 +37,9 @@ ALLOW_SFTP=false
 # Follow log output after running container.
 FOLLOW_LOGS=false
 
+# Are we bringing the CloudForest down.
+STOP_CONTAINER=false
+
 # Optional arguments before the required tag and container name
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -54,8 +57,8 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     "--stop")
-        docker-compose down
-        exit 0
+        STOP_CONTAINER=true
+        shift
         ;;
     "--help"|"--usage")
         print_help
@@ -81,8 +84,14 @@ fi
 
 if [[ ! -z $CLOUDFOREST_TAG ]]; then
     COMPOSE_FILE_ARGS="$COMPOSE_FILE_ARGS -f docker-compose-remote.yml"
+    docker-compose $COMPOSE_FILE_ARGS pull cloudforest
 else
     COMPOSE_BUILD_ARGS="--build"
+fi
+
+if [[ $STOP_CONTAINER == "true" ]]; then
+    docker-compose $COMPOSE_FILE_ARGS down
+    exit 0
 fi
 
 # Read CRA credentials

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ print_help () {
 Usage: ./run_it.sh [--tag tag_name] [--sftp] [--follow]
 
 --tag <tag_name>
-Run an image from the cloudforestphylogenomics/cloudforest_galaxy
+Run an image from the cloudforestphylo/cloudforestgalaxy:latest
 repository with the tag <tag_name>. Use latest for the most recent build from master.
 
 --sftp


### PR DESCRIPTION
- Updates the necessary configuration in `docker-compose-remote.yml`.
- Updates references to the repository in documentation and comments.
- Ensures images are pulled when using a remote image via the `--tag` option.
- Runs `docker-compose down` with the same arguments that would have been used for `up`.